### PR TITLE
Add cargo deny config files

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ocpi-tariffs-cli"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/tandemdrive/ocpi-tariffs"
 
 [[bin]]
 name = "ocpi-tariffs"

--- a/cli/deny.toml
+++ b/cli/deny.toml
@@ -1,0 +1,36 @@
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+notice = "deny"
+unsound = "deny"
+ignore = [
+    # `time` Potential segfault in the time crate
+    # https://rustsec.org/advisories/RUSTSEC-2020-0071
+    "RUSTSEC-2020-0071",
+]
+
+[bans]
+multiple-versions = "allow"
+wildcards = "deny"
+# private package can use wildcard paths such as `package.workspace = true`
+allow-wildcard-paths = true
+deny = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+
+[licenses]
+unlicensed = "deny"
+allow-osi-fsf-free = "neither"
+copyleft = "deny"
+# We want really high confidence when inferring licenses from text
+confidence-threshold = 0.93
+# ignore the local workspace crates
+private = { ignore = true }
+# (extending this list is only allowed after agreement by TD management)
+allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT"]
+
+[[licenses.exceptions]]
+allow = ["Unicode-DFS-2016"]
+name = "unicode-ident"

--- a/ocpi-tariffs/Cargo.toml
+++ b/ocpi-tariffs/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ocpi-tariffs"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/tandemdrive/ocpi-tariffs"
 
 [dependencies]
 chrono.workspace = true

--- a/ocpi-tariffs/deny.toml
+++ b/ocpi-tariffs/deny.toml
@@ -1,0 +1,36 @@
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+notice = "deny"
+unsound = "deny"
+ignore = [
+    # `time` Potential segfault in the time crate
+    # https://rustsec.org/advisories/RUSTSEC-2020-0071
+    "RUSTSEC-2020-0071",
+]
+
+[bans]
+multiple-versions = "allow"
+wildcards = "deny"
+# private package can use wildcard paths such as `package.workspace = true`
+allow-wildcard-paths = true
+deny = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+
+[licenses]
+unlicensed = "deny"
+allow-osi-fsf-free = "neither"
+copyleft = "deny"
+# We want really high confidence when inferring licenses from text
+confidence-threshold = 0.93
+# ignore the local workspace crates
+private = { ignore = true }
+# (extending this list is only allowed after agreement by TD management)
+allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT"]
+
+[[licenses.exceptions]]
+allow = ["Unicode-DFS-2016"]
+name = "unicode-ident"


### PR DESCRIPTION
I added `deny.toml` configs for use with `cargo deny`.

The `cli` package has some warnings that should be addressed.