### PR TITLE
Rm thiserror dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,8 @@ license = "MIT OR Apache-2.0"
 members = ["cli", "ocpi-tariffs"]
 
 [workspace.dependencies]
-ocpi-tariffs = { path = "ocpi-tariffs", version = "0.2.0" }
-cli = { path = "cli", package = "ocpi-tariffs-cli", version = "0.2.0" }
-
-chrono = { version = "0.4.23", features = ["serde"] }
 chrono-tz = "0.7.0"
-rust_decimal = { version = "1.26.1", features = ["serde-with-arbitrary-precision"] }
-rust_decimal_macros = "1.27.0"
-serde = { version = "1.0", features = ["derive"] }
-clap = { version = "4.1.11", features = ["derive"] }
-thiserror = { version = "1.0.40" }
+chrono = { version = "0.4.23", features = ["serde"] }
+cli = { path = "cli", package = "ocpi-tariffs-cli", version = "0.2.0" }
+ocpi-tariffs = { path = "ocpi-tariffs", version = "0.2.0" }
 serde_json = { version = "1.0" }
-console = { version = "0.15.5" }
-tabled = { version = "0.10.0", features = ["color"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,11 +12,10 @@ name = "ocpi-tariffs"
 path = "src/main.rs"
 
 [dependencies]
-clap.workspace = true
-ocpi-tariffs.workspace = true
-thiserror.workspace = true
-serde_json.workspace = true
-tabled.workspace = true
 chrono-tz.workspace = true
 chrono.workspace = true
-console.workspace = true
+clap = { version = "4.1.11", features = ["derive"] }
+console = { version = "0.15.5" }
+ocpi-tariffs.workspace = true
+serde_json.workspace = true
+tabled = { version = "0.10.0", features = ["color"] }

--- a/ocpi-tariffs/Cargo.toml
+++ b/ocpi-tariffs/Cargo.toml
@@ -8,11 +8,11 @@ description.workspace = true
 license.workspace = true
 
 [dependencies]
-chrono.workspace = true
 chrono-tz.workspace = true
-rust_decimal.workspace = true
-rust_decimal_macros.workspace = true
-serde.workspace = true
+chrono.workspace = true
+rust_decimal_macros = "1.27.0"
+rust_decimal = { version = "1.26.1", features = ["serde-with-arbitrary-precision"] }
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/ocpi-tariffs/src/lib.rs
+++ b/ocpi-tariffs/src/lib.rs
@@ -1,6 +1,8 @@
 #![deny(missing_docs)]
 #![doc = include_str!("../../README.md")]
 
+use std::fmt;
+
 /// OCPI specific structures for defining tariffs and charge sessions.
 pub mod ocpi;
 /// Module containing the functionality to price charge sessions with provided tariffs.
@@ -23,4 +25,12 @@ pub enum Error {
     /// A valid tariff must have a start date time before the start of the session and a end date
     /// time after the start of the session.
     NoValidTariff,
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("No valid tariff has been found in the list of provided tariffs")
+    }
 }


### PR DESCRIPTION
It's not worth having an extra dep for just defning a simple error type.

- Move the deps that are only used in the CLI package into it's Cargo.toml. Otherwise you're signalling that these deps are common when in fact they're only used in one package.
- Also moved deps specially for the lib into it's Cargo.toml