### PR TITLE
Add GH workflow for rustdoc.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,18 @@ jobs:
       with:
         arguments: --all-features --workspace
 
+  docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+        env:
+          RUSTDOCFLAGS: -D warnings
+      - run: cargo doc --workspace --all-features --no-deps --document-private-items
+
   outdated:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
@@ -59,4 +71,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/install@cargo-outdated
-      - run: cargo outdated --workspace -R --exit-code 1
+      - run: cargo outdated --workspace --exit-code 1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OCPI tariffs
 
-This project provides software for doing calculations with [OCPI][ocpi]
-[tariffs][tariffs]. Specifically for the [`OCPI 2.2.1`](https://evroaming.org/app/uploads/2021/11/OCPI-2.2.1.pdf)
+This project provides software for doing calculations with [OCPI](https://evroaming.org/ocpi-background/)
+[tariffs](https://github.com/ocpi/ocpi/blob/2.2.1/mod_tariffs.asciidoc#1-tariffs-module). Specifically for the [`OCPI 2.2.1`](https://evroaming.org/app/uploads/2021/11/OCPI-2.2.1.pdf)
 version.
 
 [![crates-io]](https://crates.io/crates/ocpi-tariffs "Crates.io version")

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,13 +1,13 @@
 
 # OCPI tariffs CLI
 
-This crate provides a binary for doing calculations with [OCPI][ocpi]
-[tariffs][tariffs]. Specifically for the [`OCPI 2.2.1`](https://evroaming.org/app/uploads/2021/11/OCPI-2.2.1.pdf)
+This crate provides a binary for doing calculations with [OCPI](https://evroaming.org/ocpi-background/)
+[tariffs](https://github.com/ocpi/ocpi/blob/2.2.1/mod_tariffs.asciidoc#1-tariffs-module). Specifically for the [`OCPI 2.2.1`](https://evroaming.org/app/uploads/2021/11/OCPI-2.2.1.pdf)
 version.
 
 ## Installation
 
-```ignore
+```text
 cargo install ocpi-tariffs-cli
 ```
 
@@ -21,7 +21,7 @@ The binary can be directly executed using `ocpi-tariffs`. Execute `ocpi-tariffs 
 
 To price a tariff and CDR (Charge detail record) and see a breakdown of the separate periods use `analyze`:
 
-```ignore
+```text
 Analyze a given charge detail record (CDR) against either a provided tariff structure or a tariff that is contained in the CDR itself.
 
 This command will show you a breakdown of all the calculated costs.
@@ -52,7 +52,7 @@ Options:
 
 To price a tariff and CDR and check if the calculation differs from the original CDR use `validate`:
 
-```ignore
+```text
 Validate a given charge detail record (CDR) against either a provided tariff structure or a tariff that is contained in the CDR itself.
 
 This command will show the differences between the calculated totals and the totals contained in the provided CDR.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../README.md")]
+#![doc = include_str!("../README.md")]
 
 use clap::Parser;
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../README.md")]
+#![doc = include_str!("../../README.md")]
 
 use clap::Parser;
 


### PR DESCRIPTION
Added a GH workflow for rustdoc and checking outdated deps.

The GH markdown supports more features than the Rustdoc flavor.
Rustdoc doesn't support reference links, so I replaced those with inline links.