### PR TITLE
Remove unused features from chrono, chrono-tz and serde_json deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ license = "MIT OR Apache-2.0"
 members = ["cli", "ocpi-tariffs"]
 
 [workspace.dependencies]
-chrono-tz = "0.7.0"
-chrono = { version = "0.4.23", features = ["serde"] }
+chrono-tz = { version = "0.7.0", default-features = false }
 cli = { path = "cli", package = "ocpi-tariffs-cli", version = "0.2.0" }
 ocpi-tariffs = { path = "ocpi-tariffs", version = "0.2.0" }
-serde_json = { version = "1.0" }
+serde_json = { version = "1.0", default-features = false }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 chrono-tz.workspace = true
-chrono.workspace = true
+chrono = { version = "0.4.23", default-features = false, features = ["alloc", "serde"] }
 clap = { version = "4.1.11", features = ["derive"] }
 console = { version = "0.15.5" }
 ocpi-tariffs.workspace = true

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -4,6 +4,13 @@ use chrono::DateTime;
 use chrono_tz::Tz;
 use clap::{Args, Parser, Subcommand};
 use console::style;
+use tabled::{
+    format::Format,
+    object::{Rows, Segment},
+    width::MinWidth,
+    Alignment, Modify, Panel, Style, Table, Tabled,
+};
+
 use ocpi_tariffs::{
     ocpi::{cdr::Cdr, tariff::OcpiTariff},
     pricer::{DimensionReport, Pricer, Report},
@@ -12,12 +19,6 @@ use ocpi_tariffs::{
         money::{Money, Price, Vat},
         time::HoursDecimal,
     },
-};
-use tabled::{
-    format::Format,
-    object::{Rows, Segment},
-    width::MinWidth,
-    Alignment, Modify, Panel, Style, Table, Tabled,
 };
 
 use crate::{error::Error, Result};
@@ -31,7 +32,7 @@ pub struct Cli {
 impl Cli {
     pub fn run(self) {
         if let Err(err) = self.command.run() {
-            eprintln!("{}", err);
+            eprintln!("{err}");
             exit(1);
         }
     }
@@ -169,12 +170,12 @@ impl ValidateTable {
         self.row(
             report.excl_vat,
             cdr.map(|s| s.excl_vat),
-            &format!("{} excl. VAT", name),
+            &format!("{name} excl. VAT"),
         );
         self.row(
             report.incl_vat,
             cdr.map(|s| s.incl_vat),
-            &format!("{} incl. VAT", name),
+            &format!("{name} incl. VAT"),
         );
     }
 

--- a/deny.toml
+++ b/deny.toml
@@ -3,11 +3,7 @@ vulnerability = "deny"
 unmaintained = "deny"
 notice = "deny"
 unsound = "deny"
-ignore = [
-    # `time` Potential segfault in the time crate
-    # https://rustsec.org/advisories/RUSTSEC-2020-0071
-    "RUSTSEC-2020-0071",
-]
+ignore = []
 
 [bans]
 multiple-versions = "allow"
@@ -19,6 +15,11 @@ deny = []
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
 
 [licenses]
 unlicensed = "deny"
@@ -26,10 +27,12 @@ allow-osi-fsf-free = "neither"
 copyleft = "deny"
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.93
-# ignore the local workspace crates
-private = { ignore = true }
 # (extending this list is only allowed after agreement by TD management)
 allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT"]
+
+# ignore the local workspace crates
+[licenses.private]
+ignore = true 
 
 [[licenses.exceptions]]
 allow = ["Unicode-DFS-2016"]

--- a/ocpi-tariffs/Cargo.toml
+++ b/ocpi-tariffs/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 
 [dependencies]
 chrono-tz.workspace = true
-chrono.workspace = true
+chrono = { version = "0.4.23", default-features = false }
 rust_decimal_macros = "1.27.0"
 rust_decimal = { version = "1.26.1", features = ["serde-with-arbitrary-precision"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
We can remove the suppression of  the `time` security advisory if we remove the unused `chrono` features.