### PR TITLE
Fix `[min|max]_duration` restriction in combination with `PARKING_TIME`

### DIFF
--- a/ocpi-tariffs/src/pricer.rs
+++ b/ocpi-tariffs/src/pricer.rs
@@ -189,7 +189,7 @@ impl StepSize {
             }
         }
 
-        if period.period_data.duration.is_some() {
+        if period.period_data.charging_duration.is_some() {
             if let Some(time) = components.time {
                 self.time = Some((index, time));
             }
@@ -373,7 +373,7 @@ impl Dimensions {
                 components.parking,
                 data.parking_duration.map(Into::into),
             ),
-            time: DimensionReport::new(components.time, data.duration.map(Into::into)),
+            time: DimensionReport::new(components.time, data.charging_duration.map(Into::into)),
             energy: DimensionReport::new(components.energy, data.energy),
             flat: DimensionReport::new(components.flat, Some(())),
         }

--- a/ocpi-tariffs/src/session.rs
+++ b/ocpi-tariffs/src/session.rs
@@ -118,7 +118,7 @@ impl InstantData {
     fn next(&self, state: &PeriodData, date_time: DateTime) -> Self {
         let mut next = self.clone();
 
-        next.total_duration = date_time - next.date_time;
+        next.total_duration = next.total_duration + (date_time - next.date_time);
         next.date_time = date_time;
 
         if let Some(duration) = state.charging_duration {

--- a/ocpi-tariffs/src/types/time.rs
+++ b/ocpi-tariffs/src/types/time.rs
@@ -26,7 +26,7 @@ impl<'de> Deserialize<'de> for HoursDecimal {
     {
         use serde::de::Error;
 
-        let hours = <Number as serde::Deserialize>::deserialize(deserializer)?;
+        let hours = Number::deserialize(deserializer)?;
         let duration =
             Self::from_hours_decimal(hours).map_err(|_e| D::Error::custom("overflow"))?;
         Ok(duration)
@@ -137,7 +137,7 @@ impl<'de> Deserialize<'de> for SecondsRound {
     {
         use serde::de::Error;
 
-        let seconds = <u64 as serde::Deserialize>::deserialize(deserializer)?;
+        let seconds = u64::deserialize(deserializer)?;
         let duration = Duration::seconds(
             seconds
                 .try_into()

--- a/ocpi-tariffs/test_data/grace_period_parking_time/cdr.json
+++ b/ocpi-tariffs/test_data/grace_period_parking_time/cdr.json
@@ -1,0 +1,44 @@
+{
+  "country_code": "BE",
+  "start_date_time": "2015-06-29T15:00:00Z",
+  "end_date_time": "2015-06-29T16:15:00Z",
+  "currency": "EUR",
+  "tariffs": [],
+  "charging_periods": [{
+    "start_date_time": "2015-06-29T15:00:00Z",
+    "dimensions": [{
+      "type": "PARKING_TIME",
+      "volume": 0.5
+    }]
+  }, {
+    "start_date_time": "2015-06-29T15:30:00Z",
+    "dimensions": [{
+      "type": "PARKING_TIME",
+      "volume": 0.25
+    }]
+  }, {
+    "start_date_time": "2015-06-29T15:45:00Z",
+    "dimensions": [{
+      "type": "ENERGY",
+      "volume": 10
+    }]
+  }],
+  "total_parking_cost": {
+      "excl_vat": 0.75,
+      "incl_vat": 0.75
+  },
+  "total_energy_cost": {
+      "excl_vat": 2.5,
+      "incl_vat": 2.75
+  },
+  "total_cost": {
+    "excl_vat": 3.25,
+    "incl_vat": 3.5
+  },
+  "total_energy": 10,
+  "total_time": 1.25,
+  "total_parking_time": 0.75,
+  "last_updated": "2015-06-29T22:01:13Z"
+}
+
+

--- a/ocpi-tariffs/test_data/grace_period_parking_time/tariff.json
+++ b/ocpi-tariffs/test_data/grace_period_parking_time/tariff.json
@@ -1,0 +1,44 @@
+{
+  "currency": "EUR",
+  "elements": [
+    {
+      "price_components": [
+        {
+          "type": "PARKING_TIME",
+          "price": 0.0,
+          "vat": 0.0,
+          "step_size": 1
+        }
+      ],
+      "restrictions": {
+        "min_duration": 0,
+        "max_duration": 1800
+      }
+    },
+    {
+      "price_components": [
+        {
+          "type": "PARKING_TIME",
+          "price": 3.0,
+          "vat": 0.0,
+          "step_size": 1
+        }
+      ],
+      "restrictions": {
+        "min_duration": 1800
+      }
+    },
+    {
+      "price_components": [
+        {
+          "type": "ENERGY",
+          "price": 0.25,
+          "vat": 10.0,
+          "step_size": 1
+        }
+      ]
+    }
+  ],
+  "end_date_time": "2019-06-30T23:59:59Z",
+  "last_updated": "2018-12-17T17:15:01Z"
+}


### PR DESCRIPTION
`min_duration` and `max_duration` should be compared against the actual session time, not charging time. 