### PR TITLE
Update lints

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,22 +10,44 @@ rustflags = [
     # https://doc.rust-lang.org/rustc/lints/index.html
     "-Wfuture_incompatible",
     "-Wlet_underscore",
+    "-Wnonstandard-style",
     "-Wrust_2018_compatibility",
     "-Wrust_2018_idioms",
     "-Wrust_2021_compatibility",
     "-Wtrivial_casts",
     "-Wtrivial_numeric_casts",
     "-Wunsafe_code",
+    "-Wunused",
     "-Wunused_import_braces",
+    "-Wunused_lifetimes",
+    "-Wunused_macro_rules",
+    "-Wunused_qualifications",
+    "-Wunused_tuple_struct_fields",
+    "-Wwarnings",
 
+    # This list is based off Embarks clippy list
+    # https://github.com/EmbarkStudios/rust-ecosystem/blob/main/lints.rs
+    #
+    # You can lookup the motivation for each clippy here:
     # https://rust-lang.github.io/rust-clippy/master/index.html
+    #
+    # The following lints are pending implementation, as they cause significant code churn
+    # 
+    # "-Wclippy::string_lit_as_bytes",
+    # 
+    # We also excluded the lint `clippy::map_unwrap_or` as it considers the pattern `map_or_else(.., ..)` more readable than `map(...).unwrap_or(..)`
+    # We do not.
+
     "-Aclippy::doc_markdown",
+    "-Wclippy::await_holding_lock",
+    "-Wclippy::char_lit_as_u8",
     "-Wclippy::checked_conversions",
     "-Wclippy::dbg_macro",
     "-Wclippy::debug_assert_with_mut_call",
     "-Wclippy::disallowed_macros",
     "-Wclippy::disallowed_methods",
     "-Wclippy::disallowed_types",
+    "-Wclippy::empty_enum",
     "-Wclippy::enum_glob_use",
     "-Wclippy::exit",
     "-Wclippy::explicit_deref_methods",
@@ -37,6 +59,7 @@ rustflags = [
     "-Wclippy::float_cmp_const",
     "-Wclippy::fn_params_excessive_bools",
     "-Wclippy::from_iter_instead_of_collect",
+    "-Wclippy::if_let_mutex",
     "-Wclippy::implicit_clone",
     "-Wclippy::imprecise_flops",
     "-Wclippy::inefficient_to_string",
@@ -44,21 +67,24 @@ rustflags = [
     "-Wclippy::large_digit_groups",
     "-Wclippy::large_stack_arrays",
     "-Wclippy::large_types_passed_by_value",
+    "-Wclippy::let_unit_value",
     "-Wclippy::linkedlist",
     "-Wclippy::lossy_float_literal",
     "-Wclippy::macro_use_imports",
     "-Wclippy::manual_ok_or",
-    "-Wclippy::map_err_ignore",
+    "-Wclippy::map_flatten",
     "-Wclippy::match_on_vec_items",
     "-Wclippy::match_same_arms",
     "-Wclippy::match_wildcard_for_single_variants",
     "-Wclippy::match_wild_err_arm",
     "-Wclippy::mem_forget",
+    "-Wclippy::mismatched_target_os",
     "-Wclippy::missing_enforced_import_renames",
     "-Wclippy::mutex_integer",
     "-Wclippy::mut_mut",
     "-Wclippy::needless_continue",
     "-Wclippy::needless_for_each",
+    "-Wclippy::needless_pass_by_value",
     "-Wclippy::option_option",
     "-Wclippy::path_buf_push_overwrite",
     "-Wclippy::ptr_as_ptr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "ocpi-tariffs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "ocpi-tariffs-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/ocpi-tariffs/src/pricer.rs
+++ b/ocpi-tariffs/src/pricer.rs
@@ -77,7 +77,7 @@ impl Pricer {
 
             step_size.update(index, &components, period);
 
-            let dimensions = Dimensions::new(components, &period.period_data);
+            let dimensions = Dimensions::new(&components, &period.period_data);
 
             total_charging_time = total_charging_time
                 .saturating_add(dimensions.time.volume.unwrap_or_else(HoursDecimal::zero));
@@ -414,7 +414,7 @@ pub struct Dimensions {
 }
 
 impl Dimensions {
-    pub(crate) fn new(components: PriceComponents, data: &PeriodData) -> Self {
+    pub(crate) fn new(components: &PriceComponents, data: &PeriodData) -> Self {
         Self {
             parking_time: DimensionReport::new(
                 components.parking,


### PR DESCRIPTION
I sync'd the lints from TD with ocpi-tariffs.
I added the `needless-pass-by-value` lint, Td doesn't implement this one yet as it causes a lot of churn.
See what you think.