### PR TITLE
Add `rust-version = 1.81` and fmt toml files and imports.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [build]
 target-dir = "target"
 rustdocflags = [
-    "-Arustdoc::private_intra_doc_links",
-    "-Drustdoc::broken_intra_doc_links",
+  "-Arustdoc::private_intra_doc_links",
+  "-Drustdoc::broken_intra_doc_links",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,10 +13,15 @@ path = "src/main.rs"
 
 [dependencies]
 chrono-tz.workspace = true
-chrono = { version = "0.4.38", default-features = false, features = ["alloc", "serde"] }
+chrono = { version = "0.4.38", default-features = false, features = [
+  "alloc",
+  "serde",
+] }
 clap = { version = "4.5.4", features = ["derive"] }
 console = { version = "0.15.8" }
-ocpi-tariffs = { version = "0.6.1", path = "../ocpi-tariffs", features = ["ocpi-v211"] }
+ocpi-tariffs = { version = "0.6.1", path = "../ocpi-tariffs", features = [
+  "ocpi-v211",
+] }
 serde_json.workspace = true
 serde.workspace = true
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -11,12 +11,11 @@ use std::{
 use chrono_tz::Tz;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use console::style;
-use serde::de::DeserializeOwned;
-
 use ocpi_tariffs::{
     ocpi::{cdr::Cdr, tariff::OcpiTariff, v211},
     pricer::{Pricer, Report},
 };
+use serde::de::DeserializeOwned;
 
 use crate::{error::Error, Result};
 
@@ -180,7 +179,7 @@ pub struct Validate {
 }
 
 impl Validate {
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn run(self) -> Result<()> {
         let (report, cdr, _) = self.args.load_all()?;
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,8 +1,8 @@
 disallowed-methods = [
-    { path = "std::option::Option::map_or", reason = "prefer `map(..).unwrap_or(..)` for legibility" },
-    { path = "std::option::Option::map_or_else", reason = "prefer `map(..).unwrap_or_else(..)` for legibility" },
-    { path = "std::result::Result::map_or", reason = "prefer `map(..).unwrap_or(..)` for legibility" },
-    { path = "std::result::Result::map_or_else", reason = "prefer `map(..).unwrap_or_else(..)` for legibility" },
-    { path = "std::iter::Iterator::for_each", reason = "prefer `for` for side-effects" },
-    { path = "std::iter::Iterator::try_for_each", reason = "prefer `for` for side-effects" },
+  { path = "std::option::Option::map_or", reason = "prefer `map(..).unwrap_or(..)` for legibility" },
+  { path = "std::option::Option::map_or_else", reason = "prefer `map(..).unwrap_or_else(..)` for legibility" },
+  { path = "std::result::Result::map_or", reason = "prefer `map(..).unwrap_or(..)` for legibility" },
+  { path = "std::result::Result::map_or_else", reason = "prefer `map(..).unwrap_or_else(..)` for legibility" },
+  { path = "std::iter::Iterator::for_each", reason = "prefer `for` for side-effects" },
+  { path = "std::iter::Iterator::try_for_each", reason = "prefer `for` for side-effects" },
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,7 @@ allow = ["Apache-2.0", "MIT"]
 
 # ignore the local workspace crates
 [licenses.private]
-ignore = true 
+ignore = true
 
 [[licenses.exceptions]]
 allow = ["Unicode-DFS-2016"]

--- a/ocpi-tariffs/Cargo.toml
+++ b/ocpi-tariffs/Cargo.toml
@@ -17,7 +17,9 @@ workspace = true
 chrono-tz.workspace = true
 chrono = { version = "0.4.35", default-features = false, features = ["serde"] }
 rust_decimal_macros = "1.34.2"
-rust_decimal = { version = "1.32.0", features = ["serde-with-arbitrary-precision"] }
+rust_decimal = { version = "1.32.0", features = [
+  "serde-with-arbitrary-precision",
+] }
 serde.workspace = true
 
 [dev-dependencies]

--- a/ocpi-tariffs/src/ocpi/v211/cdr.rs
+++ b/ocpi-tariffs/src/ocpi/v211/cdr.rs
@@ -1,14 +1,14 @@
 use serde::{Deserialize, Serialize};
 
 use super::tariff::OcpiTariff;
-
-use crate::{null_default, ocpi::v221};
-
-use crate::types::money::Money;
-use crate::types::{
-    electricity::{Ampere, Kwh},
-    money::Price,
-    time::{DateTime, HoursDecimal},
+use crate::{
+    null_default,
+    ocpi::v221,
+    types::{
+        electricity::{Ampere, Kwh},
+        money::{Money, Price},
+        time::{DateTime, HoursDecimal},
+    },
 };
 
 /// The CDR object describes the Charging Session and its costs. How these costs are build up etc.

--- a/ocpi-tariffs/src/ocpi/v211/tariff.rs
+++ b/ocpi-tariffs/src/ocpi/v211/tariff.rs
@@ -1,17 +1,17 @@
 //! The Tariff object describes a tariff and its properties
 
-use crate::null_default;
-
 use serde::{Deserialize, Serialize};
 use v221::tariff::CompatibilityVat;
 
-use crate::types::{
-    electricity::{Kw, Kwh},
-    money::Money,
-    time::{DateTime, DayOfWeek, OcpiDate, OcpiTime, SecondsRound},
+use crate::{
+    null_default,
+    ocpi::v221,
+    types::{
+        electricity::{Kw, Kwh},
+        money::Money,
+        time::{DateTime, DayOfWeek, OcpiDate, OcpiTime, SecondsRound},
+    },
 };
-
-use crate::ocpi::v221;
 
 /// The Tariff object describes a tariff and its properties
 #[derive(Clone, Deserialize, Serialize)]

--- a/ocpi-tariffs/src/ocpi/v221/cdr.rs
+++ b/ocpi-tariffs/src/ocpi/v221/cdr.rs
@@ -1,13 +1,13 @@
 use serde::{Deserialize, Serialize};
 
 use super::tariff::OcpiTariff;
-
-use crate::null_default;
-
-use crate::types::{
-    electricity::{Ampere, Kw, Kwh},
-    money::Price,
-    time::{DateTime, HoursDecimal},
+use crate::{
+    null_default,
+    types::{
+        electricity::{Ampere, Kw, Kwh},
+        money::Price,
+        time::{DateTime, HoursDecimal},
+    },
 };
 
 /// The CDR object describes the Charging Session and its costs. How these costs are build up etc.

--- a/ocpi-tariffs/src/ocpi/v221/tariff.rs
+++ b/ocpi-tariffs/src/ocpi/v221/tariff.rs
@@ -2,13 +2,14 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::{
-    electricity::{Ampere, Kw, Kwh},
-    money::{Money, Price, Vat},
-    time::{DateTime, DayOfWeek, OcpiDate, OcpiTime, SecondsRound},
+use crate::{
+    null_default,
+    types::{
+        electricity::{Ampere, Kw, Kwh},
+        money::{Money, Price, Vat},
+        time::{DateTime, DayOfWeek, OcpiDate, OcpiTime, SecondsRound},
+    },
 };
-
-use crate::null_default;
 
 /// The Tariff object describes a tariff and its properties
 #[derive(Clone, Deserialize, Serialize)]

--- a/ocpi-tariffs/src/pricer.rs
+++ b/ocpi-tariffs/src/pricer.rs
@@ -1,3 +1,7 @@
+use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
+use serde::Serialize;
+
 use crate::{
     ocpi::{
         cdr::Cdr,
@@ -13,10 +17,6 @@ use crate::{
     },
     Error, Result,
 };
-
-use chrono::{DateTime, Utc};
-use chrono_tz::Tz;
-use serde::Serialize;
 
 /// Pricer that encapsulates a single charge-session and a list of tariffs.
 /// To run the pricer call `build_report`. The resulting report contains the totals, subtotals and a breakdown of the
@@ -87,7 +87,7 @@ impl<'a> Pricer<'a> {
 
     /// Attempt to apply the first applicable tariff to the charge session and build a report
     /// containing the results.
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     pub fn build_report(self) -> Result<Report> {
         let cdr_tz = self.cdr.cdr_location.time_zone.as_ref();
 

--- a/ocpi-tariffs/src/restriction.rs
+++ b/ocpi-tariffs/src/restriction.rs
@@ -2,9 +2,11 @@ use std::collections::HashSet;
 
 use chrono::{Duration, NaiveDate, NaiveTime, Timelike, Weekday};
 
-use crate::ocpi::tariff::OcpiTariffRestriction;
-use crate::session::{InstantData, PeriodData};
-use crate::types::electricity::{Ampere, Kw, Kwh};
+use crate::{
+    ocpi::tariff::OcpiTariffRestriction,
+    session::{InstantData, PeriodData},
+    types::electricity::{Ampere, Kw, Kwh},
+};
 
 pub fn collect_restrictions(restriction: &OcpiTariffRestriction) -> Vec<Restriction> {
     let mut collected = Vec::new();
@@ -100,7 +102,7 @@ pub enum Restriction {
     MinDuration(Duration),
     MaxDuration(Duration),
     DayOfWeek(HashSet<Weekday>),
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     Reservation,
 }
 

--- a/ocpi-tariffs/src/session.rs
+++ b/ocpi-tariffs/src/session.rs
@@ -1,3 +1,6 @@
+use chrono::{Datelike, Duration, NaiveDate, NaiveTime, Weekday};
+use chrono_tz::Tz;
+
 use crate::{
     ocpi::cdr::{Cdr, OcpiCdrDimension, OcpiChargingPeriod},
     types::{
@@ -5,9 +8,6 @@ use crate::{
         time::DateTime,
     },
 };
-
-use chrono::{Datelike, Duration, NaiveDate, NaiveTime, Weekday};
-use chrono_tz::Tz;
 
 pub struct ChargeSession {
     pub start_date_time: DateTime,

--- a/ocpi-tariffs/src/tariff.rs
+++ b/ocpi-tariffs/src/tariff.rs
@@ -1,12 +1,13 @@
 use serde::Serialize;
 
-use crate::ocpi::tariff::{
-    CompatibilityVat, OcpiPriceComponent, OcpiTariff, OcpiTariffElement, TariffDimensionType,
+use crate::{
+    ocpi::tariff::{
+        CompatibilityVat, OcpiPriceComponent, OcpiTariff, OcpiTariffElement, TariffDimensionType,
+    },
+    restriction::{collect_restrictions, Restriction},
+    session::ChargePeriod,
+    types::{money::Money, time::DateTime},
 };
-
-use crate::restriction::{collect_restrictions, Restriction};
-use crate::session::ChargePeriod;
-use crate::types::{money::Money, time::DateTime};
 
 pub struct Tariff {
     pub id: String,
@@ -124,7 +125,7 @@ impl TariffElement {
     }
 
     // use this in the future to validate if a period is still valid when it ends.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn is_active_at_end(&self, period: &ChargePeriod) -> bool {
         for restriction in &self.restrictions {
             if !restriction.instant_validity_inclusive(&period.end_instant) {

--- a/ocpi-tariffs/src/types/money.rs
+++ b/ocpi-tariffs/src/types/money.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
 
 use super::{electricity::Kwh, number::Number, time::HoursDecimal};
 

--- a/ocpi-tariffs/src/types/time.rs
+++ b/ocpi-tariffs/src/types/time.rs
@@ -4,9 +4,8 @@ use chrono::Duration;
 use chrono_tz::Tz;
 use serde::{Deserialize, Serialize, Serializer};
 
-use crate::Error;
-
 use super::number::Number;
+use crate::Error;
 
 const SECS_IN_MIN: i64 = 60;
 const MINS_IN_HOUR: i64 = 60;
@@ -304,9 +303,8 @@ mod hour_decimal_tests {
     use chrono::Duration;
     use rust_decimal_macros::dec;
 
-    use crate::types::number::Number;
-
     use super::HoursDecimal;
+    use crate::types::number::Number;
 
     #[test]
     fn zero_minutes_should_be_zero_hours() {

--- a/ocpi-tariffs/tests/integration.rs
+++ b/ocpi-tariffs/tests/integration.rs
@@ -1,11 +1,11 @@
+use std::path::Path;
+
 use chrono_tz::Tz;
 use ocpi_tariffs::{
     ocpi::{cdr::Cdr, tariff::OcpiTariff},
     pricer::Pricer,
 };
-use std::path::Path;
 
-#[allow(clippy::needless_pass_by_value)]
 #[test_each::file(glob = "ocpi-tariffs/test_data/*/cdr*.json", name(segments = 2))]
 fn test_json(cdr: &str, path: &Path) {
     let tariff = std::fs::read_to_string(path.parent().unwrap().join("tariff.json")).unwrap();

--- a/scripts/cargo_fmt_with_imports.sh
+++ b/scripts/cargo_fmt_with_imports.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+cargo +nightly fmt -- --config group_imports=StdExternalCrate,imports_granularity=Crate


### PR DESCRIPTION
- Replace `#[allow]` with `#[expect]` (feature stabilized in Rust 1.81)
- Add `rust_version = 1.81`
- Format `*.toml` files
- Format `*.rs` file imports
- Add `cargo_fmt_with_imports.sh` to save the command used to format imports (needs +nightly)